### PR TITLE
Add slugify to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pysam
 Flask-Compress==1.0.2
 Flask-ErrorMail==0.2.2
 numpy
+slugify


### PR DESCRIPTION
On my machine, I had to install slugify to avoid an `ImportError` during the `python manage.py load_db` step.