### PR TITLE
gene.html https://github.com/konradjk/exac_browser/issues/232

### DIFF
--- a/templates/gene.html
+++ b/templates/gene.html
@@ -201,7 +201,7 @@
                     {% endwith %}
                 </div>
                 <div class="row">
-                    {% if variants_in_gene %}
+                    {% if variants_in_transcript %}
                         {% set chrom = variants_in_transcript[0].chrom %}
                         {% include 'variant_table.html' %}
                     {% else %}


### PR DESCRIPTION
This addresses issue:
https://github.com/konradjk/exac_browser/issues/232

This fixes the case when no variants exist on a transcript.

On a side note I think the transcript with the most variants should the default to be displayed rather than the canonical.